### PR TITLE
feat: adds release type to the PR title

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ if [ "$CURRENT_BRANCH" = "$HEAD_BRANCH" ]; then
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: token $GITHUB_TOKEN" \
       "$CREATE_PR_URL" \
-      -d "{\"head\":\"$CURRENT_BRANCH\",\"base\":\"$BASE_BRANCH\", \"title\": \"Merge $CURRENT_BRANCH into $BASE_BRANCH\"}"
+      -d "{\"head\":\"$CURRENT_BRANCH\",\"base\":\"$BASE_BRANCH\", \"title\": \"chore: Merge $CURRENT_BRANCH into $BASE_BRANCH\"}"
   )
     ERROR_MSG=$(echo "${GIT_CREATE_PR_RESPONSE}" | jq '.errors[0].message')
     check_create_PR_response "$ERROR_MSG"


### PR DESCRIPTION
This PR adds a release type to the title of the PR that is created.
The reason for adding this is:

- [Projen](https://github.com/medlypharmacy/medly-projen/blob/main/.github/workflows/pull-request-lint.yml) has added a new job in the Github actions to check for an appropriate release type. Name is = "Validate PR title"
- without an appropriate title, the build fails.

Error Images:
<img width="983" alt="image" src="https://user-images.githubusercontent.com/8468992/169517241-22beb724-d958-4847-b87b-fa025171f3b0.png">

